### PR TITLE
Ability to skip redirect url validation 

### DIFF
--- a/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithRedirect.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Platform } from 'react-native';
 import { Amplify, OAuthConfig } from '@aws-amplify/core';
 import {
 	AuthAction,
@@ -87,7 +88,11 @@ const oauthSignIn = async ({
 		: randomState;
 
 	const { value, method, toCodeChallenge } = generateCodeVerifier(128);
-	const redirectUri = getRedirectUrl(oauthConfig.redirectSignIn);
+
+	const redirectUri =
+		Platform.OS === 'android'
+			? oauthConfig.redirectSignIn[0]
+			: getRedirectUrl(oauthConfig.redirectSignIn);
 
 	if (isBrowser()) oAuthStore.storeOAuthInFlight(true);
 	oAuthStore.storeOAuthState(state);

--- a/packages/aws-amplify/package.json
+++ b/packages/aws-amplify/package.json
@@ -455,7 +455,7 @@
 			"name": "[Auth] OAuth Auth Flow (Cognito)",
 			"path": "./dist/esm/auth/index.mjs",
 			"import": "{ signInWithRedirect, signOut, fetchAuthSession }",
-			"limit": "21.47 kB"
+			"limit": "21.52 kB"
 		},
 		{
 			"name": "[Storage] copy (S3)",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Allow the ability to skip the redirect url validation and use the first redirect url instead.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
I enabled this for Android and I could verify that uses the first redirect url and skips http/https validation.
This is needed since Chrome Custom Tabs does not allow to redirect back into the app.
Our solution includes a custom web page that redirects back to the app automatically and we need to setup both redirect urls.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Relevant documentation is changed or added (and PR referenced)



#### Checklist for repo maintainers
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Verify E2E tests for existing workflows are working as expected or add E2E tests for newly added workflows

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
